### PR TITLE
redjubjub: make PrivateKey internal scalar public

### DIFF
--- a/src/redjubjub.rs
+++ b/src/redjubjub.rs
@@ -34,7 +34,7 @@ pub struct Signature {
     sbar: [u8; 32],
 }
 
-pub struct PrivateKey<E: JubjubEngine>(E::Fs);
+pub struct PrivateKey<E: JubjubEngine>(pub E::Fs);
 
 pub struct PublicKey<E: JubjubEngine>(pub Point<E, Unknown>);
 


### PR DESCRIPTION
So that we can construct a PrivateKey directly from an existing scalar.