### PR TITLE
Improve Pedersen hash performance

### DIFF
--- a/benches/pedersen_hash.rs
+++ b/benches/pedersen_hash.rs
@@ -1,0 +1,23 @@
+#![feature(test)]
+
+extern crate rand;
+extern crate test;
+extern crate pairing;
+extern crate sapling_crypto;
+
+use rand::{Rand, thread_rng};
+use pairing::bls12_381::Bls12;
+use sapling_crypto::jubjub::JubjubBls12;
+use sapling_crypto::pedersen_hash::{pedersen_hash, Personalization};
+
+#[bench]
+fn bench_pedersen_hash(b: &mut test::Bencher) {
+    let params = JubjubBls12::new();
+    let rng = &mut thread_rng();
+    let bits = (0..510).map(|_| bool::rand(rng)).collect::<Vec<_>>();
+    let personalization = Personalization::MerkleTree(31);
+
+    b.iter(|| {
+        pedersen_hash::<Bls12, _>(personalization, bits.clone(), &params)
+    });
+}


### PR DESCRIPTION
Implemented alongside @gtank!

We first started by implementing w-ary non-adjacent form exponentiation, which shaved about 40% of the time off running Pedersen hash (for the merkle tree). We tried also to improve the doubling performance a little bit by using the specific doubling formula rather than the generic addition formula.

Finally, we just implemented fixed window tables and shaved about 90% of the cost off.

Here are some benchmarks:

```
at first:

test bench_pedersen_hash ... bench:     452,241 ns/iter (+/- 24,567)

after wnaf:

test bench_pedersen_hash ... bench:     276,877 ns/iter (+/- 7,185)

after more optimal doubling (eyeroll at the variance):

test bench_pedersen_hash ... bench:     279,210 ns/iter (+/- 7,150)

after dedicated window tables:

test bench_pedersen_hash ... bench:      37,373 ns/iter (+/- 2,020)
```