### PR TITLE
Add must_use to operations over Edwards points

### DIFF
--- a/src/jubjub/edwards.rs
+++ b/src/jubjub/edwards.rs
@@ -164,6 +164,7 @@ impl<E: JubjubEngine> Point<E, Unknown> {
     }
 
     /// This guarantees the point is in the prime order subgroup
+    #[must_use]
     pub fn mul_by_cofactor(&self, params: &E::Params) -> Point<E, PrimeOrder>
     {
         let tmp = self.double(params)
@@ -346,6 +347,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         (x, y)
     }
 
+    #[must_use]
     pub fn negate(&self) -> Self {
         let mut p = self.clone();
 
@@ -355,6 +357,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         p
     }
 
+    #[must_use]
     pub fn double(&self, _: &E::Params) -> Self {
         // See "Twisted Edwards Curves Revisited"
         //     Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
@@ -423,6 +426,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         }
     }
 
+    #[must_use]
     pub fn add(&self, other: &Self, params: &E::Params) -> Self
     {
         // See "Twisted Edwards Curves Revisited"
@@ -495,6 +499,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         }
     }
 
+    #[must_use]
     pub fn mul<S: Into<<E::Fs as PrimeField>::Repr>>(
         &self,
         scalar: S,

--- a/src/jubjub/montgomery.rs
+++ b/src/jubjub/montgomery.rs
@@ -97,6 +97,7 @@ impl<E: JubjubEngine> Point<E, Unknown> {
     }
 
     /// This guarantees the point is in the prime order subgroup
+    #[must_use]
     pub fn mul_by_cofactor(&self, params: &E::Params) -> Point<E, PrimeOrder>
     {
         let tmp = self.double(params)
@@ -216,6 +217,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         }
     }
 
+    #[must_use]
     pub fn negate(&self) -> Self {
         let mut p = self.clone();
 
@@ -224,6 +226,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         p
     }
 
+    #[must_use]
     pub fn double(&self, params: &E::Params) -> Self {
         if self.infinity {
             return Point::zero();
@@ -280,6 +283,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         }
     }
 
+    #[must_use]
     pub fn add(&self, other: &Self, params: &E::Params) -> Self
     {
         // This is a standard affine point addition formula
@@ -330,6 +334,7 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
         }
     }
 
+    #[must_use]
     pub fn mul<S: Into<<E::Fs as PrimeField>::Repr>>(
         &self,
         scalar: S,


### PR DESCRIPTION
This reduces the likelihood of other "whoops that wasn't an inplace operation" bugs.