### PR TITLE
Do not rely on drop() to perform final accumulation step

### DIFF
--- a/src/circuit/blake2s.rs
+++ b/src/circuit/blake2s.rs
@@ -15,7 +15,7 @@ use super::uint32::{
     UInt32
 };
 
-use super::multieq::MultiEq;
+use super::multieq::{MultiEq, multi_eq};
 
 /*
 2.1.  Parameters
@@ -202,9 +202,7 @@ fn blake2s_compression<E: Engine, CS: ConstraintSystem<E>>(
         v[14] = v[14].xor(cs.namespace(|| "third xor"), &UInt32::constant(u32::max_value()))?;
     }
 
-    {
-        let mut cs = MultiEq::new(&mut cs);
-
+    multi_eq::<_, _, _, Result<(), SynthesisError>>(&mut cs, |cs| {
         for i in 0..10 {
             let mut cs = cs.namespace(|| format!("round {}", i));
 
@@ -220,7 +218,9 @@ fn blake2s_compression<E: Engine, CS: ConstraintSystem<E>>(
             mixing_g(cs.namespace(|| "mixing invocation 7"), &mut v, 2, 7,  8, 13, &m[s[12]], &m[s[13]])?;
             mixing_g(cs.namespace(|| "mixing invocation 8"), &mut v, 3, 4,  9, 14, &m[s[14]], &m[s[15]])?;
         }
-    }
+
+        Ok(())
+    })?;
 
     for i in 0..8 {
         let mut cs = cs.namespace(|| format!("h[{i}] ^ v[{i}] ^ v[{i} + 8]", i=i));

--- a/src/circuit/uint32.rs
+++ b/src/circuit/uint32.rs
@@ -419,7 +419,7 @@ mod test {
     use pairing::{Field};
     use ::circuit::test::*;
     use bellman::{ConstraintSystem};
-    use circuit::multieq::MultiEq;
+    use circuit::multieq::multi_eq;
 
     #[test]
     fn test_uint32_from_bits_be() {
@@ -542,11 +542,9 @@ mod test {
 
             let mut expected = a.wrapping_add(b).wrapping_add(c);
 
-            let r = {
-                let mut cs = MultiEq::new(&mut cs);
-                let r = UInt32::addmany(cs.namespace(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
-                r
-            };
+            let r = multi_eq(&mut cs, |cs| {
+                UInt32::addmany(cs.namespace(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap()
+            });
 
             assert!(r.value == Some(expected));
 
@@ -584,11 +582,9 @@ mod test {
             let d_bit = UInt32::alloc(cs.namespace(|| "d_bit"), Some(d)).unwrap();
 
             let r = a_bit.xor(cs.namespace(|| "xor"), &b_bit).unwrap();
-            let r = {
-                let mut cs = MultiEq::new(&mut cs);
-                let r = UInt32::addmany(cs.namespace(|| "addition"), &[r, c_bit, d_bit]).unwrap();
-                r
-            };
+            let r = multi_eq(&mut cs, |cs| {
+                UInt32::addmany(cs.namespace(|| "addition"), &[r, c_bit, d_bit]).unwrap()
+            });
 
             assert!(cs.is_satisfied());
 


### PR DESCRIPTION
The `MultiEq` API relies on `drop`, which is not guaranteed to run. By wrapping the logic in a closure we ensure the final accumulation step must be performed to proceed with execution.