### PR TITLE
Fix test_uint32_shr failing on debug builds.

### DIFF
--- a/src/circuit/uint32.rs
+++ b/src/circuit/uint32.rs
@@ -175,7 +175,7 @@ impl UInt32 {
     }
 
     pub fn shr(&self, by: usize) -> Self {
-        let by = by % 32;
+        assert!(by < 32);
 
         let fill = Boolean::constant(false);
 
@@ -656,7 +656,7 @@ mod test {
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         for _ in 0..50 {
-            for i in 0..60 {
+            for i in 0..32 {
                 let num = rng.gen();
                 let a = UInt32::constant(num).shr(i);
                 let b = UInt32::constant(num >> i);
@@ -667,6 +667,19 @@ mod test {
                 for (a, b) in a.bits.iter().zip(b.bits.iter()) {
                     assert_eq!(a.get_value().unwrap(), b.get_value().unwrap());
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint32_shr_overflow() {
+        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+
+        for _ in 0..50 {
+            for i in 32..60 {
+                let num = rng.gen();
+                let result = std::panic::catch_unwind(|| UInt32::constant(num).shr(i));
+                assert!(result.is_err());
             }
         }
     }


### PR DESCRIPTION
This makes `shr` behave differently than Rust's `>>` in release mode but IMO how `>>` works in release mode is kinda dumb -- I could see myself assuming the argument to shr or the right argument to `>>` saturates instead of taking the value mod N, and introducing security bugs that way -- so this seems safer.