### PR TITLE
Improve test_uint32_rotr to exercise the by = by % 32 line.

### DIFF
--- a/src/circuit/uint32.rs
+++ b/src/circuit/uint32.rs
@@ -629,7 +629,7 @@ mod test {
 
         let a = UInt32::constant(num);
 
-        for i in 0..32 {
+        for i in 0..60 {
             let b = a.rotr(i);
             assert_eq!(a.bits.len(), b.bits.len());
 


### PR DESCRIPTION
If the first line of `rotr` was changed to `let by = by % 33`, for example, then the existing test wouldn't catch it.